### PR TITLE
Containerized code

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,6 @@
 ^cran-comments\.md$
 ^\.DS_Store$
 ^\.Rhistory$
+^build\.sh$
+^run\.sh$
+^Dockerfile$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM pennsive/r-env:base
+
+# install anything not already in pennsive/r-env:base
+RUN r -e "install.packages('BiocManager')"
+RUN r -e "BiocManager::install(c('DelayedArray', 'HDF5Array', 'rhdf5', 'S4Vectors'))"
+RUN r -e "devtools::install_github('muschellij2/NiftiArray', dependencies = FALSE)"
+
+WORKDIR /src
+COPY . .
+ENTRYPOINT []
+CMD bash

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t pennsive/nifti-array:latest .
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run -ti --rm pennsive/nifti-array:latest


### PR DESCRIPTION
Wrote a Dockerfile so it's easier to run and more portable/reproducible/future-proof. The image built by build.sh is available on [docker hub](https://hub.docker.com/repository/docker/pennsive/nifti-array) so trying out NiftiArray is as simple as `docker run -ti pennsive/nifti-array:latest R` which'll drop you in an R shell or `docker run -d -p 80:8787 -e PASSWORD=123 pennsive/nifti-array:latest /init` to launch the browser-based R studio on http://localhost.

It also makes it easier for others to extend this in the future, if you wanted to use NiftiArray in a more production setting you could write your own Dockerfile which could be as simple as

```
FROM pennsive/nifti-array:latest
COPY . /src
CMD Rscript /src/myscript.R
```